### PR TITLE
Adding Ability to Close Connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Package dogstatsd provides a Go DogStatsD client. DogStatsD extends StatsD - add
 
     // Create the client
     c, err := dogstatsd.New("127.0.0.1:8125")
+    defer c.Close()
     if err != nil {
       log.Fatal(err)
     }

--- a/dogstatsd.go
+++ b/dogstatsd.go
@@ -7,6 +7,7 @@ histograms. Refer to http://docs.datadoghq.com/guides/dogstatsd/ for information
 Example Usage:
 		// Create the client
 		c, err := dogstatsd.New("127.0.0.1:8125")
+		defer c.Close()
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -44,6 +45,11 @@ func New(addr string) (*Client, error) {
 	}
 	client := &Client{conn: conn}
 	return client, nil
+}
+
+// Close closes the connection to the DogStatsD agent
+func (c *Client) Close() error {
+	return c.conn.Close()
 }
 
 // send handles sampling and sends the message over UDP. It also adds global namespace prefixes and tags.

--- a/dogstatsd_test.go
+++ b/dogstatsd_test.go
@@ -48,6 +48,7 @@ func TestClient(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer client.Close()
 
 	for _, tt := range dogstatsdTests {
 		client.Namespace = tt.GlobalNamespace


### PR DESCRIPTION
Currently, the dogstatsd package does not provide any capability to close the connection created to talk to the DogStatsD. To enable the connection to be closed by clients of the package, a `Close` function has been added.
