### PR TITLE
Use character (not byte) lengths in event payloads

### DIFF
--- a/dogstatsd.go
+++ b/dogstatsd.go
@@ -31,6 +31,7 @@ import (
 	"net"
 	"strings"
 	"time"
+	"unicode/utf8"
 )
 
 type Client struct {
@@ -139,7 +140,8 @@ func (c *Client) Error(title string, text string, tags []string) error {
 }
 func (c *Client) Event(title string, text string, eo *EventOpts) error {
 	var b bytes.Buffer
-	fmt.Fprintf(&b, "_e{%d,%d}:%s|%s|t:%s", len(title), len(text), title, text, eo.AlertType)
+	fmt.Fprintf(&b, "_e{%d,%d}:%s|%s|t:%s", utf8.RuneCountInString(title),
+		utf8.RuneCountInString(text), title, text, eo.AlertType)
 
 	if eo.SourceTypeName != "" {
 		fmt.Fprintf(&b, "|s:%s", eo.SourceTypeName)

--- a/dogstatsd_test.go
+++ b/dogstatsd_test.go
@@ -86,6 +86,11 @@ var eventTests = []eventTest{
 		expected: "_e{10,6}:Great News|hurray|t:success|s:flubber|#foo,bar,baz",
 	},
 	eventTest{
+		logEvent: func(c *Client) error { return c.Info("Unicode", "世界", []string{}) },
+		// Expect character, not byte lengths
+		expected: "_e{7,2}:Unicode|世界|t:info|s:flubber",
+	},
+	eventTest{
 		logEvent: func(c *Client) error {
 			eo := EventOpts{
 				DateHappened:   time.Date(2014, time.September, 18, 22, 56, 0, 0, time.UTC),


### PR DESCRIPTION
len() returns byte lengths, which isn't want we want for Unicode strings
