### PR TITLE
Cleanup & Optimizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,25 +9,27 @@ Package dogstatsd provides a Go DogStatsD client. DogStatsD extends StatsD - add
 ## Usage
 
     // Create the client
-    c, err := dogstatsd.New("127.0.0.1:8125")
-    defer c.Close()
+    c, err := dogstatsd.New("127.0.0.1:8125", "flubber.", []string{"us-east-1a"})
     if err != nil {
       log.Fatal(err)
     }
+    defer c.Close()
+
     // Prefix every metric with the app name
-    c.Namespace = "flubber."
+    c.SetGlobalNamespace("flubber.")
     // Send the EC2 availability zone as a tag with every metric
-    c.Tags = append(c.Tags, "us-east-1a")
+    c.SetGlobalTags([]string{"us-east-1a"})
+
     err = c.Gauge("request.duration", 1.2, nil, 1)
 
-	// Post info to datadog event stream
-	err = c.Info("cookie alert", "Cookies up for grabs in the kitchen!", nil)
+    // Post info to datadog event stream
+    err = c.Info("cookie alert", "Cookies up for grabs in the kitchen!", nil)
 
 ## Development
 
 Run the tests with:
 
-    $ go test
+    $ go test -v
 
 ## Documentation
 

--- a/bench_test.go
+++ b/bench_test.go
@@ -1,0 +1,61 @@
+package dogstatsd
+
+import (
+	"io"
+	"io/ioutil"
+	"testing"
+)
+
+type NopWriteCloser struct {
+	io.Writer
+}
+
+func (*NopWriteCloser) Close() error { return nil }
+
+func NewNopClient() *Client {
+	return &Client{
+		conn: &NopWriteCloser{Writer: ioutil.Discard},
+	}
+}
+
+func BenchmarkGauge(b *testing.B) {
+	c := NewNopClient()
+	for i := 0; i < b.N; i++ {
+		c.Gauge("test.gauge", 42.42, nil, 1.)
+	}
+}
+
+func BenchmarkCount(b *testing.B) {
+	c := NewNopClient()
+	for i := 0; i < b.N; i++ {
+		c.Count("test.count", 42, nil, 1.)
+	}
+}
+
+func BenchmarkHistogram(b *testing.B) {
+	c := NewNopClient()
+	for i := 0; i < b.N; i++ {
+		c.Histogram("test.histogram", 42.42, nil, 1.)
+	}
+}
+
+func BenchmarkSet(b *testing.B) {
+	c := NewNopClient()
+	for i := 0; i < b.N; i++ {
+		c.Set("test.set", "42.42", nil, 1.)
+	}
+}
+
+func BenchmarkEvent(b *testing.B) {
+	c := NewNopClient()
+	for i := 0; i < b.N; i++ {
+		c.Info("test.event.info", "Event text", nil)
+	}
+}
+
+func BenchmarkSend(b *testing.B) {
+	c := NewNopClient()
+	for i := 0; i < b.N; i++ {
+		c.send("test.send", "value", nil, 1)
+	}
+}

--- a/dogstatsd.go
+++ b/dogstatsd.go
@@ -7,14 +7,16 @@ histograms. Refer to http://docs.datadoghq.com/guides/dogstatsd/ for information
 Example Usage:
 		// Create the client
 		c, err := dogstatsd.New("127.0.0.1:8125")
-		defer c.Close()
 		if err != nil {
 			log.Fatal(err)
 		}
+		defer c.Close()
+
 		// Prefix every metric with the app name
-		c.Namespace = "flubber."
+		c.SetGlobalNamespace("flubber.")
 		// Send the EC2 availability zone as a tag with every metric
-		append(c.Tags, "us-east-1a")
+		c.SetGlobalTags([]string{"us-east-1a"})
+
 		err = c.Gauge("request.duration", 1.2, nil, 1)
 
 		// Post info to datadog event stream
@@ -25,174 +27,212 @@ dogstatsd is based on go-statsd-client.
 package dogstatsd
 
 import (
-	"bytes"
 	"fmt"
+	"io"
 	"math/rand"
 	"net"
+	"strconv"
 	"strings"
 	"time"
 	"unicode/utf8"
 )
 
+type (
+	// AlertType represents the supported alert_types of Datadog events.
+	AlertType string
+	// PriorityType represents Datadog event priority (e.g. 'normal' or 'low')
+	PriorityType string
+)
+
+// AlertType enum
+const (
+	Info    AlertType = "info"
+	Success AlertType = "success"
+	Warning AlertType = "warning"
+	Error   AlertType = "error"
+)
+
+// PriorityType enum
+const (
+	Normal PriorityType = "normal"
+	Low    PriorityType = "low"
+)
+
+const maxEventBytes = 8192
+
+// EventOpts represents detailed options for Event generation
+type EventOpts struct {
+	DateHappened   time.Time
+	Priority       PriorityType
+	Host           string
+	AggregationKey string
+	SourceTypeName string
+	Tags           []string
+	AlertType      AlertType
+}
+
+// Client represents the statsd Client.
 type Client struct {
-	conn net.Conn
-	// Namespace to prepend to all statsd calls
-	Namespace string
-	// Global tags to be added to every statsd call
-	Tags []string
+	conn        io.WriteCloser
+	eventSource string // eventSource is the Namespace truncated to the first `.`
+	namespace   string // Namespace to prepend to all statsd calls
+	tags        string // Global tags to be added to every statsd call
+
+	hasNS   bool
+	hasTags bool
 }
 
 // New returns a pointer to a new Client and an error.
-// addr must have the format "hostname:port"
+// addr must have the format "hostname:port".
 func New(addr string) (*Client, error) {
 	conn, err := net.Dial("udp", addr)
 	if err != nil {
 		return nil, err
 	}
-	client := &Client{conn: conn}
-	return client, nil
-}
-
-// Close closes the connection to the DogStatsD agent
-func (c *Client) Close() error {
-	return c.conn.Close()
+	return &Client{
+		conn: conn,
+	}, nil
 }
 
 // send handles sampling and sends the message over UDP. It also adds global namespace prefixes and tags.
 func (c *Client) send(name string, value string, tags []string, rate float64) error {
 	if rate < 1 {
-		if rand.Float64() < rate {
-			value = fmt.Sprintf("%s|@%f", value, rate)
-		} else {
+		// rand.Float64 returns between 0.0 and 1.0. When rate < 1, randomly drop the stat.
+		if rand.Float64() > rate {
 			return nil
 		}
+		value += "|@" + strconv.FormatFloat(rate, 'f', 6, 64)
 	}
 
-	if c.Namespace != "" {
-		name = fmt.Sprintf("%s%s", c.Namespace, name)
+	if c.hasNS {
+		name = c.namespace + name
 	}
 
-	tags = append(c.Tags, tags...)
+	if c.hasTags {
+		tags = append(tags, c.tags)
+	}
 	if len(tags) > 0 {
-		value = fmt.Sprintf("%s|#%s", value, strings.Join(tags, ","))
+		value += "|#" + strings.Join(tags, ",")
 	}
 
-	data := fmt.Sprintf("%s:%s", name, value)
-	_, err := c.conn.Write([]byte(data))
+	_, err := c.conn.Write([]byte(name + ":" + value))
 	return err
 }
 
-// AlertType represents the supported alert_types of Datadog events.
-type AlertType string
+// Close closes the connection to the DogStatsD agent
+func (c *Client) Close() error { return c.conn.Close() }
 
-// A Datadog event priority (e.g. 'normal' or 'low')
-type PriorityType string
-
-const (
-	Info          AlertType    = "info"
-	Success       AlertType    = "success"
-	Warning       AlertType    = "warning"
-	Error         AlertType    = "error"
-	Normal        PriorityType = "normal"
-	Low           PriorityType = "low"
-	maxEventBytes              = 8192
-)
-
-// Detailed options for Event generation
-type EventOpts struct {
-	DateHappened                         time.Time
-	Priority                             PriorityType
-	Host, AggregationKey, SourceTypeName string
-	Tags                                 []string
-	AlertType                            AlertType
+func (c *Client) newDefaultEventOpts(alertType AlertType, tags []string) *EventOpts {
+	return &EventOpts{
+		AlertType:      alertType,
+		Tags:           tags,
+		SourceTypeName: c.eventSource,
+	}
 }
 
-func newDefaultEventOpts(alertType AlertType, tags []string, namespace string) *EventOpts {
-	eo := EventOpts{
-		AlertType: alertType,
-		Tags:      tags,
-	}
-	// Use the given client namespace as the source type name, if given
-	if namespace != "" {
-		source := namespace
-		if period := strings.IndexByte(source, '.'); period > -1 {
-			source = source[:period]
-		}
-		eo.SourceTypeName = source
-	}
-	return &eo
+// Info forges an Info event
+func (c *Client) Info(title string, text string, tags []string) error {
+	return c.Event(title, text, c.newDefaultEventOpts(Info, tags))
+}
+
+// Success forges a Success event
+func (c *Client) Success(title string, text string, tags []string) error {
+	return c.Event(title, text, c.newDefaultEventOpts(Success, tags))
+}
+
+// Warning forges a Warning event
+func (c *Client) Warning(title string, text string, tags []string) error {
+	return c.Event(title, text, c.newDefaultEventOpts(Warning, tags))
+}
+
+// Error forges an Error event
+func (c *Client) Error(title string, text string, tags []string) error {
+	return c.Event(title, text, c.newDefaultEventOpts(Error, tags))
 }
 
 // Event posts to the Datadog event stream.
 // Four event types are supported: info, success, warning, error.
 // If client Namespace is set it is used as the Event source.
-func (c *Client) Info(title string, text string, tags []string) error {
-	return c.Event(title, text, newDefaultEventOpts(Info, tags, c.Namespace))
-}
-func (c *Client) Success(title string, text string, tags []string) error {
-	return c.Event(title, text, newDefaultEventOpts(Success, tags, c.Namespace))
-}
-func (c *Client) Warning(title string, text string, tags []string) error {
-	return c.Event(title, text, newDefaultEventOpts(Warning, tags, c.Namespace))
-}
-func (c *Client) Error(title string, text string, tags []string) error {
-	return c.Event(title, text, newDefaultEventOpts(Error, tags, c.Namespace))
-}
 func (c *Client) Event(title string, text string, eo *EventOpts) error {
-	var b bytes.Buffer
-	fmt.Fprintf(&b, "_e{%d,%d}:%s|%s|t:%s", utf8.RuneCountInString(title),
-		utf8.RuneCountInString(text), title, text, eo.AlertType)
+	// Can't use `len()` because we accept utf8
+	titleLen, textLen := utf8.RuneCountInString(title), utf8.RuneCountInString(text)
+
+	eventStr := "_e{" + strconv.FormatInt(int64(titleLen), 10) + "," + strconv.FormatInt(int64(textLen), 10) + "}:" + title + "|" + text + "|t:" + string(eo.AlertType)
 
 	if eo.SourceTypeName != "" {
-		fmt.Fprintf(&b, "|s:%s", eo.SourceTypeName)
+		eventStr += "|s:" + eo.SourceTypeName
 	}
 	if !eo.DateHappened.IsZero() {
-		fmt.Fprintf(&b, "|d:%d", eo.DateHappened.Unix())
+		eventStr += "|d:" + strconv.FormatInt(eo.DateHappened.Unix(), 10)
 	}
 	if eo.Priority != "" {
-		fmt.Fprintf(&b, "|p:%s", eo.Priority)
+		eventStr += "|p:" + string(eo.Priority)
 	}
 	if eo.Host != "" {
-		fmt.Fprintf(&b, "|h:%s", eo.Host)
+		eventStr += "|h:" + eo.Host
 	}
 	if eo.AggregationKey != "" {
-		fmt.Fprintf(&b, "|k:%s", eo.AggregationKey)
+		eventStr += "|k:" + eo.AggregationKey
 	}
-	tags := append(c.Tags, eo.Tags...)
-	format := "|#%s"
-	for _, t := range tags {
-		fmt.Fprintf(&b, format, t)
-		format = ",%s"
+	tags := eo.Tags
+	if c.hasTags {
+		tags = append(eo.Tags, c.tags)
 	}
-
-	bytes := b.Bytes()
-	if len(bytes) > maxEventBytes {
-		return fmt.Errorf("Event '%s' payload is too big (more that 8KB), event discarded", title)
+	if len(tags) > 0 {
+		eventStr += "|#" + strings.Join(tags, ",")
 	}
-	_, err := c.conn.Write(bytes)
+	if len(eventStr) > maxEventBytes {
+		return fmt.Errorf("Event %q payload is too big (more that 8KB), event discarded", title)
+	}
+	_, err := c.conn.Write([]byte(eventStr))
 	return err
 }
 
-// Gauges measure the value of a metric at a particular time
+// Gauge measures the value of a metric at a particular time
 func (c *Client) Gauge(name string, value float64, tags []string, rate float64) error {
-	stat := fmt.Sprintf("%f|g", value)
+	stat := strconv.FormatFloat(value, 'f', 6, 64) + "|g"
 	return c.send(name, stat, tags, rate)
 }
 
-// Counters track how many times something happened per second
+// Count tracks how many times something happened per second
 func (c *Client) Count(name string, value int64, tags []string, rate float64) error {
-	stat := fmt.Sprintf("%d|c", value)
+	stat := strconv.FormatInt(value, 10) + "|c"
 	return c.send(name, stat, tags, rate)
 }
 
-// Histograms track the statistical distribution of a set of values
+// Histogram tracks the statistical distribution of a set of values
 func (c *Client) Histogram(name string, value float64, tags []string, rate float64) error {
-	stat := fmt.Sprintf("%f|h", value)
+	stat := strconv.FormatFloat(value, 'f', 6, 64) + "|h"
 	return c.send(name, stat, tags, rate)
 }
 
-// Sets count the number of unique elements in a group
+// Set counts the number of unique elements in a group
 func (c *Client) Set(name string, value string, tags []string, rate float64) error {
-	stat := fmt.Sprintf("%s|s", value)
+	stat := value + "|s"
 	return c.send(name, stat, tags, rate)
+}
+
+// SetGlobalTags sets the global tags.
+func (c *Client) SetGlobalTags(tags []string) {
+	c.hasTags = len(tags) != 0
+	c.tags = strings.Join(tags, ",")
+}
+
+// GetGlobalTags returns the current global tags
+func (c *Client) GetGlobalTags() []string {
+	return strings.Split(c.tags, ",")
+}
+
+// SetGlobalNamespace sets the global namespace and infers the eventSource name
+func (c *Client) SetGlobalNamespace(namespace string) {
+	c.hasNS = namespace != ""
+	c.namespace = namespace
+	if period := strings.IndexByte(namespace, '.'); period > -1 {
+		c.eventSource = namespace[:period]
+	}
+}
+
+// GetGlobalNamespace returns the current global namespace
+func (c *Client) GetGlobalNamespace() string {
+	return c.namespace
 }


### PR DESCRIPTION
- This PR make the code golint and gofmt -s compliant.
- Removes all the `fmt` calls and replace with faster alternative.
- Use setters for global namespace and tags
- Use io.WriteCloser instead of net.Conn to allow for easy Mock / Extension

Benchmark before:

```
BenchmarkGauge           1000000              1302 ns/op
BenchmarkCount           2000000               834 ns/op
BenchmarkHistogram       1000000              1283 ns/op
BenchmarkSet             2000000               823 ns/op
BenchmarkEvent           1000000              1318 ns/op
BenchmarkSend            3000000               516 ns/op
```

After:

```
BenchmarkGauge           2000000               727 ns/op
BenchmarkCount          10000000               214 ns/op
BenchmarkHistogram       2000000               728 ns/op
BenchmarkSet            10000000               143 ns/op
BenchmarkEvent           3000000               478 ns/op
BenchmarkSend           20000000               108 ns/op
```
